### PR TITLE
[ui] [build] Build the frontend for the native architecture

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build frontend -t frontend --output=type=docker
           mkdir frontend/output
-          docker cp $(docker create --rm frontend):/app/build frontend/output/build/
+          docker cp $(docker create --rm frontend x):/app/build frontend/output/build/
           docker buildx build -f frontend/Dockerfile-helper frontend --platform linux/amd64,linux/arm64 -t ghcr.io/spr-networks/super_frontend:latest --push 
       -
         name: Build arm64 test containers

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -12,7 +12,7 @@ fi
 
 # remove prebuilt images
 FOUND_PREBUILT_IMAGE=false
-for SERVICE in $(docker-compose config --service); do
+for SERVICE in $(docker-compose config --services); do
   # keep the prebuilt frontend image
   if [ "$SERVICE" = "frontend" ]; then
     continue

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,4 +5,4 @@ COPY . ./
 RUN --mount=type=tmpfs,target=/app/node_modules --mount=type=tmpfs,target=/usr/local/share/ (yarn install; yarn run build)
 
 FROM scratch
-COPY --from=build /app/ /app
+COPY --from=build /app/build/ /app/build/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17 as build
+FROM --platform=$BUILDPLATFORM node:17 as build
 
 WORKDIR /app
 COPY . ./

--- a/frontend/gen_frontend.sh
+++ b/frontend/gen_frontend.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 rm -rf ./frontend/build
-if [ -z LOCALUI ]; then
-  docker cp $(docker create --rm frontend):/app/build ./frontend/build
-else
-  docker cp $(docker create --rm ghcr.io/spr-networks/super_frontend):/build ./frontend/build
-fi
+docker cp \
+  $(docker create --rm ghcr.io/spr-networks/super_frontend dummy):/app/build \
+  ./frontend/build


### PR DESCRIPTION
This modifies the `build` container in the multi-stage build to always use the native architecture, since the resulting JavaScript files are platform independent. This will still result in `linux/amd64` and `linux/arm64` images in the end, but the code will only have to be built once.