### PR TITLE
[build] Use buildx bake to make multi-platform images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Docker Image ARM64 CI
+name: Docker Image CI
 
 on:
   push:
@@ -23,14 +23,12 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Authenticate to ghcr
+        if: github.event_name == 'push'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       -
-        name: Build arm64 test containers
+        name: Build and push containers
         run: |
           cp -R base/template_configs configs
-          export DOCKER_DEFAULT_PLATFORM=linux/arm64
-          ./build_docker_compose.sh
-      -
-        name: Push images
-        run: |
-          docker-compose push
+          ./build_docker_compose.sh \
+            --set "*.platform=linux/amd64,linux/arm64" \
+            `[ ${{ github.event_name }} = "push" ] && echo "--push"`

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,6 @@
 name: Docker Image CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [ push, pull_request ]
 
 jobs:
 
@@ -23,7 +19,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Authenticate to ghcr
-        if: github.event_name == 'push'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       -
         name: Build and push containers
@@ -31,4 +26,4 @@ jobs:
           cp -R base/template_configs configs
           ./build_docker_compose.sh \
             --set "*.platform=linux/amd64,linux/arm64" \
-            `[ ${{ github.event_name }} = "push" ] && echo "--push"`
+            `[ "${{ github.event_name }}" = "push" -a "${{ github.ref_name }}" = "main" ] && echo "--push"`

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ https://demo.supernetworks.org/
 ## Updating 
 #### Building from scratch
 ```bash
-docker-compose pull
-./build.sh
+./build_docker_compose.sh
 docker-compose up -d
 ```
 
+For performance and to minimize wear on SD cards, the build uses a memory-backed filesystem. On memory-limited devices, this can cause build failures if memory is exhausted. In this case, you can provide the build argument `--set "*.args.USE_TMPFS=false"`.
+
+
 #### Using prebuilt containers
 ```bash
-docker-compose -f docker-compose-prebuilt.yml pull
-docker-compose -f docker-compose-prebuilt.yml up -d
+docker-compose pull
+docker-compose up -d
 ```
 
 ## Useful Links
@@ -37,4 +39,3 @@ docker-compose -f docker-compose-prebuilt.yml up -d
 * Documentation Home: https://www.supernetworks.org/pages/docs/intro/
 * Raspberry Pi 4 Setup https://www.supernetworks.org/pages/docs/pi4b
 * General Setup Guide https://www.supernetworks.org/pages/docs/setup_run_spr
-

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,7 +11,10 @@ ENV PATH="/usr/local/go/bin:$PATH"
 COPY code/ /code/
 
 WORKDIR /code
-RUN --mount=type=tmpfs,target=/root/go/ (go build -ldflags "-s -w" -o /api)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags "-s -w" -o /api
 
 
 FROM ubuntu:22.04

--- a/api_sample_plugin/Dockerfile
+++ b/api_sample_plugin/Dockerfile
@@ -10,7 +10,10 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.ta
 ENV PATH="/usr/local/go/bin:$PATH"
 COPY code/ /code/
 
-RUN --mount=type=tmpfs,target=/root/go/ (go build -ldflags "-s -w" -o /api_sample_plugin /code/sample_plugin.go)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags "-s -w" -o /api_sample_plugin /code/sample_plugin.go
 
 
 FROM ubuntu:22.04

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -12,7 +12,7 @@ fi
 
 # remove prebuilt images
 FOUND_PREBUILT_IMAGE=false
-for SERVICE in $(docker-compose config --service); do
+for SERVICE in $(docker-compose config --services); do
   # keep the prebuilt frontend image
   if [ "$SERVICE" = "frontend" ]; then
     continue

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -1,8 +1,4 @@
 #!/bin/bash -eu
-
-export DOCKER_BUILDKIT=1 # or configure in daemon.json
-export COMPOSE_DOCKER_CLI_BUILD=1
-
 if [ '!' -d "configs/" ]; then
   echo Configs not initialized
   echo Copy base/template_configs to ./configs and set up base/config/config.sh and base/config/auth_users.json
@@ -57,9 +53,35 @@ docker pull ghcr.io/spr-networks/super_frontend:latest
 
 BUILDARGS=""
 if [ -f .github_creds ]; then
-  BUILDARGS="--build-arg GITHUB_CREDS=`cat .github_creds`"
+  BUILDARGS="--set *.args.GITHUB_CREDS=`cat .github_creds`"
 fi
-docker-compose build ${BUILDARGS} $@
+
+# We use docker buildx so we can build multi-platform images. Unfortunately,
+# a limitation is that multi-platform images cannot be loaded from the builder
+# into Docker.
+docker buildx create --name super-builder --driver docker-container \
+  2>/dev/null || true
+
+# Look for any images that would be built multi-platform
+IS_MULTIPLATFORM=$(
+  docker buildx bake \
+    --builder super-builder \
+    --file docker-compose.yml \
+    ${BUILDARGS} "$@" \
+    --print --progress none \
+  | jq 'any(.target[].platforms//[]|map(split(",";"")[])|unique; length >= 2)'
+)
+
+# If this is a single-platform build, then by default load it into Docker
+echo Is this a multi-platform build? ${IS_MULTIPLATFORM}
+if [ "$IS_MULTIPLATFORM" = "false" ]; then
+  BUILDARGS="$BUILDARGS --load"
+fi
+
+docker buildx bake \
+  --builder super-builder \
+  --file docker-compose.yml \
+  ${BUILDARGS} "$@"
 
 ret=$?
 

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -9,11 +9,6 @@ fi
 # remove prebuilt images
 FOUND_PREBUILT_IMAGE=false
 for SERVICE in $(docker-compose config --services); do
-  # keep the prebuilt frontend image
-  if [ "$SERVICE" = "frontend" ]; then
-    continue
-  fi
-
   IS_PREBUILT=$(docker inspect \
     --format '{{ index .Config.Labels "org.supernetworks.ci" }}' \
     "ghcr.io/spr-networks/super_${SERVICE}" \
@@ -47,9 +42,6 @@ mkdir -p state/dns/
 mkdir -p state/wifi/
 mkdir -p state/wifi/sta_mac_iface_map/
 touch state/dns/local_mappings state/dhcp/leases.txt
-
-#pull the prebuilt frontend
-docker pull ghcr.io/spr-networks/super_frontend:latest
 
 BUILDARGS=""
 if [ -f .github_creds ]; then

--- a/dhcp/Dockerfile
+++ b/dhcp/Dockerfile
@@ -15,9 +15,11 @@ ENV CC=clang
 ARG CACHEBUST=1
 RUN git clone https://github.com/spr-networks/coredhcp
 WORKDIR /code/coredhcp
-
-# Using BUILDKIT, build inside of a ramfs
-RUN --mount=type=tmpfs,target=/root/go/ (go build -o /coredhcpd ./cmds/coredhcp; go build -o /coredhcp_client ./cmds/exdhcp/dhclient/)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -o /coredhcpd ./cmds/coredhcp && \
+    go build -o /coredhcp_client ./cmds/exdhcp/dhclient/
 
 
 FROM ubuntu:22.04

--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -21,8 +21,10 @@ ARG CACHEBUST=1
 RUN git clone https://github.com/coredns/coredns.git --depth 1
 WORKDIR /code/coredns/
 
-# Using BUILDKIT, build inside of a ramfs
-RUN --mount=type=tmpfs,target=/root/go/ go generate && \
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+   [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+   go generate && \
    go get github.com/spr-networks/coredns-jsonlog && \
    go get github.com/spr-networks/coredns-block && \
    go get github.com/spr-networks/coredns-rebinding_protection && \

--- a/dyndns/Dockerfile
+++ b/dyndns/Dockerfile
@@ -10,11 +10,13 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.ta
 ENV PATH="/usr/local/go/bin:$PATH"
 RUN git clone https://github.com/TimothyYe/godns.git
 WORKDIR godns/cmd/godns
-RUN go mod download
-RUN go build
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go mod download && go build
 WORKDIR /code/
 COPY code/* .
-RUN go build
+RUN --mount=type=tmpfs,target=/tmpfs go build
 
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive

--- a/flowgather/Dockerfile
+++ b/flowgather/Dockerfile
@@ -11,7 +11,10 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.ta
 ENV PATH="/usr/local/go/bin:$PATH"
 ENV CC=clang
 COPY code/ /code/
-RUN --mount=type=tmpfs,target=/root/go/ go mod tidy && go build -ldflags="-s -w" -o /flowgather
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go mod tidy && go build -ldflags="-s -w" -o /flowgather
 COPY scripts /scripts/
 
 FROM ubuntu:22.04

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,13 @@ FROM --platform=$BUILDPLATFORM node:17 as build
 
 WORKDIR /app
 COPY . ./
-RUN --mount=type=tmpfs,target=/app/node_modules --mount=type=tmpfs,target=/usr/local/share/ (yarn install; yarn run build)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && \
+        mkdir /tmpfs/cache /tmpfs/node_modules && \
+        ln -s /tmpfs/node_modules /app/node_modules && \
+        ln -s /tmpfs/cache /usr/local/share/.cache; \
+    yarn install && yarn run build
 
 FROM alpine
 COPY --from=build /app/build/ /app/build/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,4 +5,4 @@ COPY . ./
 RUN --mount=type=tmpfs,target=/app/node_modules --mount=type=tmpfs,target=/usr/local/share/ (yarn install; yarn run build)
 
 FROM alpine
-COPY --from=build /app/ /app
+COPY --from=build /app/build/ /app/build/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17 as build
+FROM --platform=$BUILDPLATFORM node:17 as build
 
 WORKDIR /app
 COPY . ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=tmpfs,target=/tmpfs \
         mkdir /tmpfs/cache /tmpfs/node_modules && \
         ln -s /tmpfs/node_modules /app/node_modules && \
         ln -s /tmpfs/cache /usr/local/share/.cache; \
-    yarn install && yarn run build
+    yarn install --network-timeout 86400000 && yarn run build
 
 FROM alpine
 COPY --from=build /app/build/ /app/build/

--- a/multicast_udp_proxy/Dockerfile
+++ b/multicast_udp_proxy/Dockerfile
@@ -9,11 +9,15 @@ RUN curl -O https://dl.google.com/go/go1.17.linux-${TARGETARCH}.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:$PATH"
 ENV CC=clang
-RUN go mod init multicastproxy
-RUN go get golang.org/x/net/ipv4@latest
-RUN go get github.com/vishvananda/netlink@latest
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go mod init multicastproxy && \
+    go get golang.org/x/net/ipv4@latest && \
+    go get github.com/vishvananda/netlink@latest
 COPY code/multicastproxy.go /code/
-RUN go build -ldflags="-s -w" multicastproxy.go
+RUN --mount=type=tmpfs,target=/tmpfs \
+    go build -ldflags="-s -w" multicastproxy.go
 
 FROM  ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive

--- a/plugin-lookup/Dockerfile
+++ b/plugin-lookup/Dockerfile
@@ -9,7 +9,10 @@ ENV PATH="/usr/local/go/bin:$PATH"
 RUN mkdir /code
 WORKDIR /code
 COPY code/ /code/
-RUN --mount=type=tmpfs,target=/root/go/ (go build -ldflags "-s -w" -o /lookup_plugin /code/lookup_plugin.go)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags "-s -w" -o /lookup_plugin /code/lookup_plugin.go
 
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive

--- a/superd/Dockerfile
+++ b/superd/Dockerfile
@@ -10,7 +10,10 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.ta
 ENV PATH="/usr/local/go/bin:$PATH"
 COPY code/ /code/
 WORKDIR /code/
-RUN go build -ldflags "-s -w" -o /superd
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags "-s -w" -o /superd
 
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive

--- a/wifid/Dockerfile
+++ b/wifid/Dockerfile
@@ -19,7 +19,10 @@ RUN curl -O https://dl.google.com/go/go1.17.linux-${TARGETARCH}.tar.gz
 RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:$PATH"
 COPY code/main.go /code/
-RUN go build -ldflags="-s -w" -o /hostap_dhcp_helper main.go
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags="-s -w" -o /hostap_dhcp_helper main.go
 
 # Build hostapd
 ARG CACHEBUST=1

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -10,7 +10,10 @@ RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.linux-${TARGETARCH}.ta
 ENV PATH="/usr/local/go/bin:$PATH"
 COPY code/ /code/
 
-RUN --mount=type=tmpfs,target=/root/go/ (go build -ldflags "-s -w" -o /wireguard_plugin /code/wireguard_plugin.go)
+ARG USE_TMPFS=true
+RUN --mount=type=tmpfs,target=/tmpfs \
+    [ "$USE_TMPFS" = "true" ] && ln -s /tmpfs /root/go; \
+    go build -ldflags "-s -w" -o /wireguard_plugin /code/wireguard_plugin.go
 
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
An experiment to build multi-platform images in CI.

Multi-platform images in Docker are kind of a mess. You have to build them with a `buildx` builder. In this patch I modified `build_docker_compose.sh` to use `buildx bake` which is the `buildx` equivalent of `docker compose`.

Unfortunately, unlike `docker build`, with `buildx build` the resulting images are not automatically exposed under `docker images`, but you can pass `--load` to copy them over. Except, `--load` only works for single-platform images! So if you are building a multi-platform image, you pretty much *have* to push it directly to the registry. This is fine in CI, since that's probably what you want anyway, but it sucks for local development.

So I taught `build_docker_compose.sh` to determine if it is doing a *single*-platform build, and if so, it will automatically `--load` it into the local Docker image list.

Also, it doesn't attempt to push to the registry for pull requests, so contributed pull requests (like this one!) won't fail for lack of permissions.

This stacks on top of #48 and reimplements part of #30 (without the caching part).