### PR TITLE
Syncfix

### DIFF
--- a/api/code/api.go
+++ b/api/code/api.go
@@ -118,7 +118,8 @@ func saveConfig() {
 
 var UNIX_WIFID_LISTENER = TEST_PREFIX + "/state/wifi/apisock"
 var UNIX_DHCPD_LISTENER = TEST_PREFIX + "/state/dhcp/apisock"
-var UNIX_WIREGUARD_LISTENER = TEST_PREFIX + "/state/plugins/wireguard/apisock"
+var UNIX_WIREGUARD_LISTENER_PATH = TEST_PREFIX + "/state/plugins/wireguard/"
+var UNIX_WIREGUARD_LISTENER = UNIX_WIREGUARD_LISTENER_PATH + "apisock"
 
 func ipAddr(w http.ResponseWriter, r *http.Request) {
 	cmd := exec.Command("ip", "-j", "addr")
@@ -1779,6 +1780,10 @@ func main() {
 		panic(err)
 	}
 
+	// 1. Wireguard may be disabled and the path might not exist,
+	// 2. The container has not started yet for the first time
+	// -> Make the directory path regardless
+	_ = os.MkdirAll(UNIX_WIREGUARD_LISTENER_PATH, 0664)
 	os.Remove(UNIX_WIREGUARD_LISTENER)
 	unixWireguardListener, err := net.Listen("unix", UNIX_WIREGUARD_LISTENER)
 	if err != nil {

--- a/api/code/firewall.go
+++ b/api/code/firewall.go
@@ -875,8 +875,11 @@ func deleteForwardBlock(br ForwardingBlockRule) error {
 
 var BASE_READY = TEST_PREFIX + "/state/base/ready"
 func SyncBaseContainer() {
+
 	// Wait for the base container to grab the flock
-	file, err := os.Open(BASE_READY)
+
+
+	file, err := os.Open(BASE_READY, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		fmt.Println("[-] Failed to open base ready file", err)
 		return

--- a/api/code/firewall.go
+++ b/api/code/firewall.go
@@ -879,7 +879,7 @@ func SyncBaseContainer() {
 	// Wait for the base container to grab the flock
 
 
-	file, err := os.Open(BASE_READY, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(BASE_READY, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		fmt.Println("[-] Failed to open base ready file", err)
 		return

--- a/api/code/firewall.go
+++ b/api/code/firewall.go
@@ -890,7 +890,7 @@ func SyncBaseContainer() {
 	for err == nil {
 		// grab the lock exclusively. If this succeeds, that means base
 		// did not finish initializing yet. Unlock and retry after a second.
-		err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 		if err == nil {
 			//release the lock -- and wait for bash
 			syscall.Flock(int(file.Fd()), syscall.LOCK_UN)

--- a/base/scripts/startup.sh
+++ b/base/scripts/startup.sh
@@ -36,4 +36,4 @@ fi
 /scripts/perftune.sh
 
 #mark initialization as finished
-flock /state/base/foo bash -c "while true; do sleep 100000; done"
+flock /state/base/ready bash -c "while true; do sleep 100000; done"

--- a/base/scripts/startup.sh
+++ b/base/scripts/startup.sh
@@ -34,4 +34,6 @@ fi
 
 # performance tuning
 /scripts/perftune.sh
-while true; do sleep 100000; done
+
+#mark initialization as finished
+flock /state/base/foo bash -c "while true; do sleep 100000; done"

--- a/docker-compose-virt.yml
+++ b/docker-compose-virt.yml
@@ -30,6 +30,7 @@ services:
     logging: *default-logging
     volumes:
       - ./configs/base/:/configs/base/
+      - ./state/base/:/state/base/
   superd:
     container_name: superd
     image: ghcr.io/spr-networks/super_superd
@@ -143,6 +144,7 @@ services:
       - ./state/dhcp/:/state/dhcp/
       - ./state/dns/:/state/dns/
       - ./state/api/:/state/api/
+      - ./state/base/:/state/base/
       - ./state/plugins/:/state/plugins/
       - ./state/public/:/state/public/
       - ./frontend/build:/ui/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     logging: *default-logging
     volumes:
       - ./configs/base/:/configs/base/
+      - ./state/base/:/state/base/
   superd:
     container_name: superd
     image: ghcr.io/spr-networks/super_superd
@@ -181,6 +182,7 @@ services:
       - ./state/dhcp/:/state/dhcp/
       - ./state/dns/:/state/dns/
       - ./state/api/:/state/api/
+      - ./state/base/:/state/base/
       - ./state/plugins/:/state/plugins/
       - ./state/public/:/state/public/
       - ./frontend/build:/ui/


### PR DESCRIPTION
@lts-po  please review. This adds a FLOCK between base and API to make sure that the API only runs after base has loaded nft_rules.sh. Need to make sure this is correct before deploying