### PR TITLE
coredns now uses go 1.20 #patch

### DIFF
--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -7,8 +7,8 @@ RUN mkdir /code
 WORKDIR /code
 
 ARG TARGETARCH
-RUN curl -O https://dl.google.com/go/go1.19.linux-${TARGETARCH}.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.linux-${TARGETARCH}.tar.gz
+RUN curl -O https://dl.google.com/go/go1.20.linux-${TARGETARCH}.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.linux-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:$PATH"
 
 


### PR DESCRIPTION
This updates the build for coredns to golang 1.20