### PR TITLE
DB & DHCP Bug fixes

### DIFF
--- a/api/code/firewall.go
+++ b/api/code/firewall.go
@@ -240,9 +240,15 @@ func getDefaultGatewayLocked(dev string) (string, error) {
 		}
 	}
 
-	//otherwise guess that DHCP exists
-	// at the start. NOTE: this will fail if DHCP
-	// is elsewhere.
+	// first check the state file
+	stateFile := "/state/dhcp-client/gateway." + dev
+	router, err := ioutil.ReadFile(stateFile)
+	if err == nil && string(router) != "" {
+		return string(router), nil
+	}
+
+	//otherwise guess that  the router is at the start as a fallback.
+	//NOTE: this will fail if DHCP is elsewhere.
 
 	ifaces, err := net.Interfaces()
 	if err != nil {

--- a/db/code/cmd/boltapi/main.go
+++ b/db/code/cmd/boltapi/main.go
@@ -159,7 +159,7 @@ func main() {
 			if err != nil {
 				log.Println(err)
 			}
-			time.Sleep( (i < 3 ? 1 : 5) * time.Second)
+			time.Sleep(3 * time.Second)
 		}
 		log.Fatal("failed to establish connection to sprbus")
 	}()

--- a/db/code/cmd/boltapi/main.go
+++ b/db/code/cmd/boltapi/main.go
@@ -154,13 +154,12 @@ func main() {
 	go boltapi.CheckSizeLoop(db, config, *gDebug)
 
 	go func() {
-		//retry 3 times to set this up
-		for i := 3; i > 0; i-- {
+		for i := 30; i > 0; i-- {
 			err = sprbus.HandleEvent("", handleLogEvent)
 			if err != nil {
 				log.Println(err)
 			}
-			time.Sleep(1 * time.Second)
+			time.Sleep( (i < 3 ? 1 : 5) * time.Second)
 		}
 		log.Fatal("failed to establish connection to sprbus")
 	}()

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -87,7 +87,8 @@ services:
     logging: *default-logging
     entrypoint: /scripts/client.sh
     volumes:
-      - ./configs/base/:/configs/base/
+      - ./configs/base/:/configs/base/:ro
+      - ./state/dhcp-client/:/state/dhcp-client/
   dns:
     container_name: superdns
     image: ghcr.io/spr-networks/super_dns:${RELEASE_VERSION:-latest}${RELEASE_CHANNEL:-}
@@ -222,6 +223,7 @@ services:
       - ./state/api/:/state/api/
       - ./state/backups/:/state/backups/
       - ./state/base/:/state/base/
+      - ./state/dhcp-client/:/state/dhcp-client/
       - ./state/plugins/:/state/plugins/
       - ./state/public/:/state/public/
       - ./frontend/build:/ui/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,8 @@ services:
     logging: *default-logging
     entrypoint: /scripts/client.sh
     volumes:
-      - ./configs/base/:/configs/base/
+      - ./configs/base/:/configs/base/:ro
+      - ./state/dhcp-client/:/state/dhcp-client/
   dns:
     container_name: superdns
     image: ghcr.io/spr-networks/super_dns:${RELEASE_VERSION:-latest}${RELEASE_CHANNEL:-}
@@ -218,6 +219,7 @@ services:
       - ./state/api/:/state/api/
       - ./state/backups/:/state/backups/
       - ./state/base/:/state/base/
+      - ./state/dhcp-client/:/state/dhcp-client/
       - ./state/plugins/:/state/plugins/
       - ./state/public/:/state/public/
       - ./frontend/build:/ui/


### PR DESCRIPTION
Bug fixes:
- Address DHCP upstream assumption, by storing the first router from dhcp into /state/dhcp-client for the API to use
- DB timeout to connect to API is too short, and db errors out early. 