### PR TITLE
Fixes for reproducible container builds #patch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,19 +49,16 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
       -
-        name: Compute SOURCE_DATE_EPOCH (commit time) and push flag
+        name: Set SOURCE_DATE_EPOCH and push flag
         id: repro
         run: |
-          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+          echo "SOURCE_DATE_EPOCH=0" >> "$GITHUB_ENV"
           push=false
           if { [ "${{ github.event_name }}" = "workflow_run" ] && [ "${{ github.ref_name }}" = "main" ]; } \
              || { [ -n "${{ env.RELEASE_CHANNEL }}" ] && [ "${{ github.event_name }}" = "push" ]; }; then
             push=true
           fi
           echo "push=$push" >> "$GITHUB_OUTPUT"
-      -
-        name: Normalize source mtimes for reproducible COPY layers
-        run: git ls-files -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
       -
         name: Authenticate to Docker Hub
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,6 +60,9 @@ jobs:
           fi
           echo "push=$push" >> "$GITHUB_OUTPUT"
       -
+        name: Normalize source mtimes for reproducible COPY layers
+        run: git ls-files -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
+      -
         name: Authenticate to Docker Hub
         if: ${{ vars.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,10 @@
 
 # Secure Programmable Router (SPR) Release Notes
 
+## v1.1.5
+** Fixes **
+- FS timestamp fixes for bit-reproducible docker builds
+
 ## v1.1.4
 ** Fixes **
 - iOS UI glitches

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,6 +3,10 @@ ARG CONTAINER_TEMPLATE_REF=ghcr.io/spr-networks/container_template@sha256:295e44
 ARG SOURCE_DATE_EPOCH
 FROM ${CONTAINER_TEMPLATE_REF}
 ENV DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_SNAPSHOT
+RUN set -eux; \
+    printf 'Types: deb\nURIs: https://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${UBUNTU_SNAPSHOT}" > /etc/apt/sources.list.d/ubuntu.sources; \
+    printf 'APT::Install-Recommends "false";\nAcquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99reproducible
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack iptables isc-dhcp-client && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY scripts /scripts
 

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -23,17 +23,13 @@ if [ -f "$REPRO_ENV" ]; then
     BAKE_SET+=(--set "*.args.${k}=${v}")
   done < <(grep -vE '^[[:space:]]*(#|$)' "$REPRO_ENV")
 fi
-export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct 2>/dev/null || echo 0)}"
+# Use epoch 0 so BuildKit's rewrite-timestamp clamp normalizes every file's
+# mtime to a single value, regardless of host filesystem state.
+export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
 BAKE_SET+=(--set "*.args.SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}")
 echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
 # shellcheck disable=SC1090
 [ -f "$REPRO_ENV" ] && . "$REPRO_ENV"
-
-# rewrite-timestamp only clamps mtimes newer than SOURCE_DATE_EPOCH; force all
-# tracked files to a single value so COPY layers don't depend on host state.
-if [ -d .git ]; then
-  git ls-files -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}" 2>/dev/null || true
-fi
 
 # remove prebuilt images
 FOUND_PREBUILT_IMAGE=false

--- a/build_docker_compose.sh
+++ b/build_docker_compose.sh
@@ -29,6 +29,12 @@ echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
 # shellcheck disable=SC1090
 [ -f "$REPRO_ENV" ] && . "$REPRO_ENV"
 
+# rewrite-timestamp only clamps mtimes newer than SOURCE_DATE_EPOCH; force all
+# tracked files to a single value so COPY layers don't depend on host state.
+if [ -d .git ]; then
+  git ls-files -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}" 2>/dev/null || true
+fi
+
 # remove prebuilt images
 FOUND_PREBUILT_IMAGE=false
 for SERVICE in $(docker-compose config --services); do
@@ -87,8 +93,15 @@ then
     docker-compose --file ${plugin}/docker-compose.yml build "$@" || exit 1
   done
 else
-  # buildx (docker-container) for multi-platform + reproducible exporter. Pin the
-  # BuildKit backend (rewrite-timestamp needs >= 0.13).
+  # Recreate super-builder if its BuildKit image doesn't match BUILDKIT_REF.
+  if docker buildx inspect super-builder >/dev/null 2>&1; then
+    CURRENT_BUILDKIT=$(docker buildx inspect super-builder \
+      | sed -n 's/.*image="\([^"]*\)".*/\1/p' | head -1)
+    if [ -n "${BUILDKIT_REF}" ] && [ "$CURRENT_BUILDKIT" != "${BUILDKIT_REF}" ]; then
+      echo "super-builder has wrong BuildKit image, recreating"
+      docker buildx rm super-builder
+    fi
+  fi
   docker buildx create --name super-builder --driver docker-container \
     --driver-opt "image=${BUILDKIT_REF}" \
     2>/dev/null || true

--- a/ppp/Dockerfile
+++ b/ppp/Dockerfile
@@ -3,6 +3,10 @@ ARG CONTAINER_TEMPLATE_REF=ghcr.io/spr-networks/container_template@sha256:295e44
 ARG SOURCE_DATE_EPOCH
 FROM ${CONTAINER_TEMPLATE_REF}
 ENV DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_SNAPSHOT
+RUN set -eux; \
+    printf 'Types: deb\nURIs: https://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${UBUNTU_SNAPSHOT}" > /etc/apt/sources.list.d/ubuntu.sources; \
+    printf 'APT::Install-Recommends "false";\nAcquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99reproducible
 RUN apt-get update && apt-get install -y --no-install-recommends jq ppp && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY scripts /scripts
 ENTRYPOINT ["/scripts/startup.sh"]

--- a/superd/Dockerfile
+++ b/superd/Dockerfile
@@ -41,12 +41,16 @@ RUN --mount=type=tmpfs,target=/tmpfs \
 FROM ${CONTAINER_TEMPLATE_REF}
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG UBUNTU_SNAPSHOT
 ARG DOCKER_CE_VERSION=5:29.5.3-1~ubuntu.24.04~noble
 ARG DOCKER_CE_CLI_VERSION=5:29.5.3-1~ubuntu.24.04~noble
 ARG CONTAINERD_VERSION=2.2.4-1~ubuntu.24.04~noble
 ARG DOCKER_BUILDX_PLUGIN_VERSION=0.34.1-1~ubuntu.24.04~noble
 ARG DOCKER_COMPOSE_PLUGIN_VERSION=5.1.4-1~ubuntu.24.04~noble
 
+RUN set -eux; \
+    printf 'Types: deb\nURIs: https://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${UBUNTU_SNAPSHOT}" > /etc/apt/sources.list.d/ubuntu.sources; \
+    printf 'APT::Install-Recommends "false";\nAcquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99reproducible
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl
 RUN install -m 0755 -d /etc/apt/keyrings
 COPY scripts/docker.asc /etc/apt/keyrings/docker.asc

--- a/wifi_uplink/Dockerfile
+++ b/wifi_uplink/Dockerfile
@@ -3,6 +3,10 @@ ARG CONTAINER_TEMPLATE_REF=ghcr.io/spr-networks/container_template@sha256:295e44
 ARG SOURCE_DATE_EPOCH
 FROM ${CONTAINER_TEMPLATE_REF}
 ENV DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_SNAPSHOT
+RUN set -eux; \
+    printf 'Types: deb\nURIs: https://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${UBUNTU_SNAPSHOT}" > /etc/apt/sources.list.d/ubuntu.sources; \
+    printf 'APT::Install-Recommends "false";\nAcquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99reproducible
 RUN apt-get update && apt-get install -y --no-install-recommends isc-dhcp-client jq wpasupplicant wireless-regdb && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY scripts /scripts
 ENTRYPOINT ["/scripts/startup.sh"]


### PR DESCRIPTION
Turns out SOURCE_DATE_EPOCH=0 is the way to go since some filesystem timestamps are not updated otherwise