### PR TITLE
Fix plugin network discovery and startup races #patch

### DIFF
--- a/api/code/plugins.go
+++ b/api/code/plugins.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,6 +35,7 @@ var OldMeshGitURL = "github.com/spr-networks/mesh_extension"
 var MeshdSocketPath = TEST_PREFIX + "/state/plugins/mesh/socket"
 var DbSocketPath = TEST_PREFIX + "/state/plugins/db/socket"
 var CustomComposeAllowPath = TEST_PREFIX + "/configs/base/custom_compose_paths.json"
+var extensionStartMtx sync.Mutex
 
 type NetworkCapabilities struct {
 	Interface string
@@ -861,33 +863,87 @@ func removePluginNetworkCapabilities(plugin PluginConfig) error {
 }
 
 func getPluginContainerIP(interfaceName string) (string, error) {
-	// Use the shared dockerRequest function to inspect the network
-	data, err := dockerRequest("GET", "/v1.41/networks/"+interfaceName, nil)
-	if err != nil {
-		return "", err
-	}
-
-	var networkInfo struct {
-		Containers map[string]struct {
-			IPv4Address string `json:"IPv4Address"`
-		} `json:"Containers"`
-	}
-
-	err = json.Unmarshal(data, &networkInfo)
-	if err != nil {
-		return "", err
-	}
-
-	// Find the first container on this network
-	for _, container := range networkInfo.Containers {
-		if container.IPv4Address != "" {
-			// Extract IP from CIDR notation (e.g., "172.20.0.2/16" -> "172.20.0.2")
-			ip := strings.Split(container.IPv4Address, "/")[0]
+	// Compose normally prefixes network names with its project name, while
+	// NetworkCapabilities.Interface is the Linux bridge name. Try the direct
+	// name first for explicitly named networks, then resolve project-scoped
+	// networks by their bridge driver option.
+	directData, directErr := dockerRequest("GET", "/v1.41/networks/"+url.PathEscape(interfaceName), nil)
+	if directErr == nil {
+		if ip, err := pluginContainerIPFromNetwork(directData); err == nil {
 			return ip, nil
 		}
 	}
 
-	return "", fmt.Errorf("no container found on network %s", interfaceName)
+	data, err := dockerRequest("GET", "/v1.41/networks", nil)
+	if err != nil {
+		return "", fmt.Errorf("inspect network %s: %v; list networks: %w", interfaceName, directErr, err)
+	}
+
+	networkIDs, err := dockerNetworkIDsForBridge(data, interfaceName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, networkID := range networkIDs {
+		data, err = dockerRequest("GET", "/v1.41/networks/"+url.PathEscape(networkID), nil)
+		if err != nil {
+			continue
+		}
+		if ip, ipErr := pluginContainerIPFromNetwork(data); ipErr == nil {
+			return ip, nil
+		}
+	}
+
+	return "", fmt.Errorf("no container found on Docker network for bridge %s", interfaceName)
+}
+
+type dockerPluginNetwork struct {
+	ID         string            `json:"Id"`
+	Name       string            `json:"Name"`
+	Options    map[string]string `json:"Options"`
+	Containers map[string]struct {
+		IPv4Address string `json:"IPv4Address"`
+	} `json:"Containers"`
+}
+
+func pluginContainerIPFromNetwork(data []byte) (string, error) {
+	var networkInfo dockerPluginNetwork
+	if err := json.Unmarshal(data, &networkInfo); err != nil {
+		return "", err
+	}
+
+	for _, container := range networkInfo.Containers {
+		if container.IPv4Address != "" {
+			return strings.SplitN(container.IPv4Address, "/", 2)[0], nil
+		}
+	}
+
+	return "", errors.New("network has no attached container with an IPv4 address")
+}
+
+func dockerNetworkIDsForBridge(data []byte, interfaceName string) ([]string, error) {
+	var networks []dockerPluginNetwork
+	if err := json.Unmarshal(data, &networks); err != nil {
+		return nil, err
+	}
+
+	var networkIDs []string
+	for _, network := range networks {
+		if network.Options["com.docker.network.bridge.name"] != interfaceName {
+			continue
+		}
+		if network.ID != "" {
+			networkIDs = append(networkIDs, network.ID)
+		} else if network.Name != "" {
+			networkIDs = append(networkIDs, network.Name)
+		}
+	}
+
+	if len(networkIDs) == 0 {
+		return nil, fmt.Errorf("no Docker network uses bridge %s", interfaceName)
+	}
+
+	return networkIDs, nil
 }
 
 func restartExtension(composeFilePath string) bool {
@@ -1028,6 +1084,8 @@ func installPlus() error {
 }
 
 func startExtensionServices() error {
+	extensionStartMtx.Lock()
+	defer extensionStartMtx.Unlock()
 
 	if PlusEnabled() {
 		//log into GHCR for PLUS

--- a/api/code/plugins_network_test.go
+++ b/api/code/plugins_network_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPluginContainerIPFromNetwork(t *testing.T) {
+	data := []byte(`{"Containers":{"container-id":{"IPv4Address":"172.30.117.3/24"}}}`)
+
+	got, err := pluginContainerIPFromNetwork(data)
+	if err != nil {
+		t.Fatalf("pluginContainerIPFromNetwork() error = %v", err)
+	}
+	if got != "172.30.117.3" {
+		t.Fatalf("pluginContainerIPFromNetwork() = %q, want %q", got, "172.30.117.3")
+	}
+}
+
+func TestDockerNetworkIDsForBridge(t *testing.T) {
+	data := []byte(`[
+		{"Id":"unrelated","Name":"other_default","Options":{"com.docker.network.bridge.name":"other"}},
+		{"Id":"network-id","Name":"spr-dnscrypt_dnscryptnet","Options":{"com.docker.network.bridge.name":"spr-dnscrypt"}}
+	]`)
+
+	got, err := dockerNetworkIDsForBridge(data, "spr-dnscrypt")
+	if err != nil {
+		t.Fatalf("dockerNetworkIDsForBridge() error = %v", err)
+	}
+	want := []string{"network-id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dockerNetworkIDsForBridge() = %v, want %v", got, want)
+	}
+}
+
+func TestDockerNetworkIDsForBridgeMissing(t *testing.T) {
+	_, err := dockerNetworkIDsForBridge([]byte(`[]`), "spr-dnscrypt")
+	if err == nil {
+		t.Fatal("dockerNetworkIDsForBridge() error = nil, want an error")
+	}
+}

--- a/superd/code/compose_lock_test.go
+++ b/superd/code/compose_lock_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLockComposeCommandSerializesSameComposeFile(t *testing.T) {
+	unlock := lockComposeCommand("plugins/user/spr-dnscrypt/docker-compose.yml")
+	acquired := make(chan struct{})
+
+	go func() {
+		defer lockComposeCommand("plugins/user/spr-dnscrypt/docker-compose.yml")()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second command acquired the same compose-file lock early")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	unlock()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second command did not acquire the released compose-file lock")
+	}
+}
+
+func TestLockComposeCommandAllowsDifferentComposeFiles(t *testing.T) {
+	unlock := lockComposeCommand("plugins/user/spr-dnscrypt/docker-compose.yml")
+	defer unlock()
+
+	otherUnlock := lockComposeCommand("plugins/user/spr-tor/docker-compose.yml")
+	otherUnlock()
+}

--- a/superd/code/superd.go
+++ b/superd/code/superd.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -56,6 +57,14 @@ var ReleaseChannelFile = "configs/base/release_channel"
 var ReleaseVersionFile = "configs/base/release_version"
 
 var ReleaseInfoMtx sync.Mutex
+var composeCommandLocks sync.Map
+
+func lockComposeCommand(composeFile string) func() {
+	value, _ := composeCommandLocks.LoadOrStore(composeFile, &sync.Mutex{})
+	mutex := value.(*sync.Mutex)
+	mutex.Lock()
+	return mutex.Unlock
+}
 
 func getReleaseVersion() string {
 	ReleaseInfoMtx.Lock()
@@ -127,7 +136,7 @@ func getDefaultCompose() string {
 	return "docker-compose.yml"
 }
 
-func composeCommand(composeFileIN string, target string, command string, optional string, new_docker bool) {
+func composeCommand(composeFileIN string, target string, command string, optional string, new_docker bool) error {
 	args := []string{}
 	release_channel := ""
 	release_version := ""
@@ -155,6 +164,9 @@ func composeCommand(composeFileIN string, target string, command string, optiona
 		composeFile = defaultCompose
 	}
 
+	unlock := lockComposeCommand(composeFile)
+	defer unlock()
+
 	reloadComposeWhitelist()
 
 	composeAllowed := false
@@ -167,7 +179,7 @@ func composeCommand(composeFileIN string, target string, command string, optiona
 
 	if composeAllowed == false {
 		fmt.Println("Compose file path is not whitelisted")
-		return
+		return fmt.Errorf("compose file path is not whitelisted: %s", composeFile)
 	}
 
 	/*
@@ -274,15 +286,21 @@ func composeCommand(composeFileIN string, target string, command string, optiona
 		args = append([]string{"compose"}, args...)
 	}
 
-	_, err = exec.Command(cmd, args...).Output()
+	output, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		argS := fmt.Sprintf(cmd + " " + strings.Join(args, " "))
-		errString := err.Error() + " |" + argS
+		argS := strings.Join(append([]string{cmd}, args...), " ")
+		errString := err.Error()
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			errString += ": " + detail
+		}
+		errString += " |" + argS
 		fmt.Println("failure: " + errString)
 		//tbd good place for a sprbus event
 		sprbus.Publish("plugin:docker:failure", map[string]string{"Reason": "docker command failed", "Message": errString, "ComposeFile": composeFileIN})
-
+		return errors.New(errString)
 	}
+
+	return nil
 
 }
 
@@ -311,7 +329,9 @@ func update(w http.ResponseWriter, r *http.Request) {
 func start(w http.ResponseWriter, r *http.Request) {
 	target := r.URL.Query().Get("service")
 	compose := r.URL.Query().Get("compose_file")
-	composeCommand(compose, target, "up", "-d", true)
+	if err := composeCommand(compose, target, "up", "-d", true); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func stop(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes user-plugin installs and automatic custom-interface policy setup.

- serialize overlapping extension start passes and same-compose operations
- propagate Docker Compose stderr and failures back to the API
- discover Compose-prefixed networks by Linux bridge name
- add focused network-discovery and concurrency tests

Validated with the router `super_superd` Compose image and a real `spr-dnscrypt` start.